### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It is a custom `ListView` with a header that displays pictures from an URL. It t
 
 ### How do I use the thing?
 
-Add `compile 'me.emmano:blurstickyheaderlistview:0.1.+'` to the `dependencies{}` in your build.gradle. If you do not aleady have `jcenter()` added to your project, do so by adding the following to build.gradle:
+Add `implementation 'me.emmano:blurstickyheaderlistview:0.1.+'` to the `dependencies{}` in your build.gradle. If you do not aleady have `jcenter()` added to your project, do so by adding the following to build.gradle:
 
     repositories {
         jcenter()


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.